### PR TITLE
Django 2.0 compatibility

### DIFF
--- a/drf_autodocs/endpoint.py
+++ b/drf_autodocs/endpoint.py
@@ -85,7 +85,7 @@ class Endpoint:
 
     @staticmethod
     def _get_complete_path(pattern, prefix=None):
-        return prefix + simplify_regex(pattern._regex)
+        return prefix + simplify_regex(pattern.pattern._regex)
 
     def _get_serializer_fields(self, serializer):
         fields = []

--- a/drf_autodocs/endpoint.py
+++ b/drf_autodocs/endpoint.py
@@ -85,7 +85,12 @@ class Endpoint:
 
     @staticmethod
     def _get_complete_path(pattern, prefix=None):
-        return prefix + simplify_regex(pattern.pattern._regex)
+        if hasattr(pattern, "_regex"):
+            regex = pattern._regex  # Django < 2.0
+        else:
+            regex = pattern.pattern._regex  # Django 2.0+
+            
+        return prefix + simplify_regex(regex)
 
     def _get_serializer_fields(self, serializer):
         fields = []

--- a/drf_autodocs/endpoint.py
+++ b/drf_autodocs/endpoint.py
@@ -85,11 +85,7 @@ class Endpoint:
 
     @staticmethod
     def _get_complete_path(pattern, prefix=None):
-        if hasattr(pattern, "_regex"):
-            regex = pattern._regex  # Django < 2.0
-        else:
-            regex = pattern.pattern._regex  # Django 2.0+
-            
+        regex = pattern._regex if hasattr(pattern, "_regex") else pattern.pattern._regex
         return prefix + simplify_regex(regex)
 
     def _get_serializer_fields(self, serializer):

--- a/drf_autodocs/parser.py
+++ b/drf_autodocs/parser.py
@@ -5,7 +5,7 @@ try:
     from django.urls import URLPattern as RegexURLPattern
     from django.urls import URLResolver as RegexURLResolver
 except:
-    -from django.core.urlresolvers import RegexURLResolver, RegexURLPattern	    
+    from django.core.urlresolvers import RegexURLResolver, RegexURLPattern	    
 from addict import Dict
 from rest_framework.views import APIView
 from .endpoint import Endpoint

--- a/drf_autodocs/parser.py
+++ b/drf_autodocs/parser.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from importlib import import_module
 from django.utils.module_loading import import_string
-from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
+from django.urls import URLPattern, URLResolver
 from addict import Dict
 from rest_framework.views import APIView
 from .endpoint import Endpoint
@@ -48,15 +48,15 @@ class TreeAPIParser(BaseAPIParser):
 
     def parse_tree(self, urlpatterns, parent_node, prefix=''):
         for pattern in urlpatterns:
-            if isinstance(pattern, RegexURLResolver):
-                child_node_name = simplify_regex(pattern._regex).strip('/') if pattern._regex else ""
+            if isinstance(pattern, URLResolver):
+                child_node_name = simplify_regex(pattern.pattern._regex).strip('/') if pattern.pattern and pattern.pattern._regex else ""
                 self.parse_tree(
                     urlpatterns=pattern.url_patterns,
                     parent_node=parent_node[child_node_name] if child_node_name else parent_node,
                     prefix='%s/%s' % (prefix, child_node_name)
                 )
 
-            elif isinstance(pattern, RegexURLPattern) and self._is_drf_pattern(pattern):
+            if isinstance(pattern, URLPattern) and self._is_drf_pattern(pattern):
                 api_endpoint = Endpoint(pattern, prefix)
                 parent_node[api_endpoint.name] = api_endpoint
 


### PR DESCRIPTION
Django 2.0 made some changes to RegexURLResolver and RegexURLPattern.  This pull request adds Django 2.0 compatibility while still retaining pre-2.0 compatibilty.

I've tried to make this as uninvasive as possible.
